### PR TITLE
GERONIMO-6884 - Fix SocketFactory creation

### DIFF
--- a/geronimo-mail_2.1_impl/geronimo-mail_2.1_provider/src/main/java/org/apache/geronimo/mail/util/MailConnection.java
+++ b/geronimo-mail_2.1_impl/geronimo-mail_2.1_provider/src/main/java/org/apache/geronimo/mail/util/MailConnection.java
@@ -354,10 +354,22 @@ public class MailConnection {
                 // done indirectly, we need to invoke the method using reflection.
                 // This retrieves a factory instance.
                 //Method getDefault = factoryClass.getMethod("getDefault", new Class[0]); //TODO check instantiation of socket factory
-                Object defFactory = factoryClass.newInstance();// getDefault.invoke(new Object(), new Object[0]);
+                // Object defFactory = factoryClass.newInstance();// getDefault.invoke(new Object(), new Object[0]);
                 // now that we have the factory, there are two different createSocket() calls we use,
                 // depending on whether we have a localAddress override.
 
+                Object defFactory = null;
+                try {
+                	defFactory = factoryClass.newInstance();
+                } catch (Throwable t) {
+                	Method getDefault = factoryClass.getMethod("getDefault", new Class[0]); //TODO check instantiation of socket factory
+                	defFactory = getDefault.invoke(new Object(), new Object[0]);                    	
+                }
+                
+                if (defFactory == null) {
+                	throw new Exception("Can not create factory class " + factoryClass.getName());
+                }
+                
                 if (localAddress != null && !layer) {
                     // retrieve the createSocket(String, int, InetAddress, int) method.
                     Class[] createSocketSig = new Class[] { String.class, Integer.TYPE, InetAddress.class, Integer.TYPE };

--- a/geronimo-mail_2.1_impl/geronimo-mail_2.1_provider/src/main/java/org/apache/geronimo/mail/util/MailConnection.java
+++ b/geronimo-mail_2.1_impl/geronimo-mail_2.1_provider/src/main/java/org/apache/geronimo/mail/util/MailConnection.java
@@ -358,18 +358,18 @@ public class MailConnection {
                 // now that we have the factory, there are two different createSocket() calls we use,
                 // depending on whether we have a localAddress override.
 
-                Object defFactory = null;
+                Object defFactory;
                 try {
                 	defFactory = factoryClass.newInstance();
                 } catch (Throwable t) {
                 	Method getDefault = factoryClass.getMethod("getDefault", new Class[0]); //TODO check instantiation of socket factory
                 	defFactory = getDefault.invoke(new Object(), new Object[0]);                    	
+
+                	if (defFactory == null) {
+                    	throw new Exception("Can not create factory class '" + factoryClass.getName() + "' neither by creating a new instance or using getDefault()", t);
+                    }
                 }
-                
-                if (defFactory == null) {
-                	throw new Exception("Can not create factory class " + factoryClass.getName());
-                }
-                
+                                
                 if (localAddress != null && !layer) {
                     // retrieve the createSocket(String, int, InetAddress, int) method.
                     Class[] createSocketSig = new Class[] { String.class, Integer.TYPE, InetAddress.class, Integer.TYPE };


### PR DESCRIPTION
try to instantiate socketFactoryClass. If it fails try to use the geDefault method. This is the way documented in JavaDoc and also used by i.E. angus-mail.

getDefault is the only way to get fallback to "javax.net.ssl.SSLSocketFactory" work. Because SSLSocketFactory is an abstract class and not instantiable without subclassing.