### PR TITLE
Ensure to flush the buffered output stream

### DIFF
--- a/geronimo-mail_2.1_impl/geronimo-mail_2.1_provider/src/main/java/org/apache/geronimo/mail/transport/nntp/NNTPConnection.java
+++ b/geronimo-mail_2.1_impl/geronimo-mail_2.1_provider/src/main/java/org/apache/geronimo/mail/transport/nntp/NNTPConnection.java
@@ -372,6 +372,7 @@ public class NNTPConnection extends MailConnection {
             mimeOut.writeSMTPTerminator();
             // and flush the data to send it along
             mimeOut.flush();
+            this.outputStream.flush(); // most of the time MIMEOutputStream#flush does nothing so ensure we actually flush the data
         } catch (IOException e) {
             throw new MessagingException("I/O error posting message", e);
         } catch (MessagingException e) {

--- a/geronimo-mail_2.1_impl/geronimo-mail_2.1_provider/src/main/java/org/apache/geronimo/mail/util/MailConnection.java
+++ b/geronimo-mail_2.1_impl/geronimo-mail_2.1_provider/src/main/java/org/apache/geronimo/mail/util/MailConnection.java
@@ -661,7 +661,12 @@ public class MailConnection {
     public void closeServerConnection()
     {
         try {
-            socket.close();
+            if (outputStream != null) {
+                outputStream.flush();
+            }
+            if(socket != null) {
+                socket.close();
+            }
         } catch (IOException ignored) {
         }
 


### PR DESCRIPTION
In #1 a BufferedOutputStream was introduced. We must ensure it is flushed before closing the socket and after other (command) writes. Ideally, it should be flushed after each command to guarantee timely delivery.

This is mostly done in the code base. I've added it to two missing locations.